### PR TITLE
fix: correctly handle auth on frontend

### DIFF
--- a/front/components/ElnLayout.tsx
+++ b/front/components/ElnLayout.tsx
@@ -3,6 +3,8 @@ import Link from 'next/link';
 import { useRouter } from 'next/router';
 import React, { useState, useMemo } from 'react';
 
+import useAuth from '../hooks/useAuth';
+
 import MenuDropDown from './MenuDropDown';
 import { ZakodiumSolidSvg } from './tailwind-ui';
 
@@ -13,7 +15,7 @@ interface ElnLayoutProps {
 export default function ElnLayout({ children }: ElnLayoutProps) {
   const router = useRouter();
   const [mobileNavOpen, setMobileNavOpen] = useState(false);
-
+  const { isAuth } = useAuth();
   const ROUTES = useMemo(() => {
     return [
       {
@@ -23,6 +25,12 @@ export default function ElnLayout({ children }: ElnLayoutProps) {
       { label: 'Users', pathname: `/eln/users` },
     ];
   }, []);
+
+  if (!isAuth) {
+    // eslint-disable-next-line no-console
+    router.push('/login').catch((err) => console.error(err));
+    return null;
+  }
 
   const { pathname } = router;
   const currentLabel =

--- a/front/pages/_app.tsx
+++ b/front/pages/_app.tsx
@@ -13,6 +13,7 @@ import {
   ToastNotificationCenter,
 } from '../components/tailwind-ui';
 import AddonsContext from '../contexts/AddonsContext';
+import AuthContext from '../contexts/AuthContext';
 import { client } from '../graphql/apollo';
 import { useElnQuery } from '../hooks/useElnQuery';
 
@@ -29,6 +30,12 @@ function SetupEln({ children }: SetupElnProps) {
     error: addonsError,
   } = useElnQuery('/addons');
 
+  const {
+    isLoading: authLoading,
+    data: authData = { isAuth: false },
+    error: authError,
+  } = useElnQuery('/auth');
+
   if (addonsError) {
     return (
       <NotificationProvider>
@@ -41,7 +48,19 @@ function SetupEln({ children }: SetupElnProps) {
     );
   }
 
-  if (addonsLoading) {
+  if (authError) {
+    return (
+      <NotificationProvider>
+        <NotificationCenter position="bottom-right" />
+        <ToastNotificationCenter position="bottom" />
+        <ErrorPage subtitle="There was a little problem." title="Oooops">
+          Failed to get auth status : {authError}
+        </ErrorPage>
+      </NotificationProvider>
+    );
+  }
+
+  if (addonsLoading || authLoading) {
     return (
       <div className="flex justify-center items-center w-full h-full">
         <div className="flex flex-col items-center">
@@ -56,7 +75,7 @@ function SetupEln({ children }: SetupElnProps) {
 
   return (
     <AddonsContext.Provider value={addonsData}>
-      {children}
+      <AuthContext.Provider value={authData}>{children}</AuthContext.Provider>
     </AddonsContext.Provider>
   );
 }


### PR DESCRIPTION
Until now, the auth state was set on login with the informations provided by the auth form.
Now, the auth state is also get and set on the back-office layout.