### PR TITLE
Allow empty status for events and files

### DIFF
--- a/addons/events/Queries/filteredEvents.ts
+++ b/addons/events/Queries/filteredEvents.ts
@@ -13,25 +13,22 @@ import { Event } from '../Models/Event';
 export default function filteredEvents(
   filterBy: GqlQueryEventsArgs['filterBy'],
 ) {
-  const {
-    topic,
-    processorId,
-    status = [GqlEventStatus.PENDING],
-    fileId,
-  } = filterBy || {};
+  const { topic, processorId, status = [], fileId } = filterBy || {};
 
-  let query: Filter<ModelAttributes<Event>> = {
-    $or: [
-      { processors: { $elemMatch: { 'history.0.status': { $in: status } } } },
-    ],
-  };
+  let query: Filter<ModelAttributes<Event>> = {};
 
   if (processorId) {
     query.processors = { $elemMatch: { processorId } };
   }
-  if (status?.includes(GqlEventStatus.PENDING)) {
-    query.$or?.push({ processors: { $size: 0 } });
-    query.$or?.push({ processors: { history: { $size: 0 } } });
+  if (status && status.length !== 0) {
+    query.$or = [
+      { processors: { $elemMatch: { 'history.0.status': { $in: status } } } },
+    ];
+
+    if (status.includes(GqlEventStatus.PENDING)) {
+      query.$or?.push({ processors: { $size: 0 } });
+      query.$or?.push({ processors: { history: { $size: 0 } } });
+    }
   }
 
   if (topic) query.topic = topic;

--- a/front/src/addons/events/components/EventFormFilter.tsx
+++ b/front/src/addons/events/components/EventFormFilter.tsx
@@ -46,8 +46,7 @@ const schema = yup.object().shape({
         label: yup.string().required(),
       }),
     )
-    .nullable()
-    .min(1),
+    .nullable(),
 });
 const selectOrderOptions = [
   { value: SortDirection.ASC, label: selectOrder[SortDirection.ASC] },

--- a/front/src/addons/fileSync/pages/files/TableFilesFiltered.tsx
+++ b/front/src/addons/fileSync/pages/files/TableFilesFiltered.tsx
@@ -106,8 +106,7 @@ const schema = yup.object().shape({
         label: yup.string().required(),
       }),
     )
-    .nullable()
-    .min(1),
+    .nullable(),
 });
 
 const selectOrderOptions = [

--- a/front/src/addons/fileSync/pages/files/TableFilesSync/DirRow.tsx
+++ b/front/src/addons/fileSync/pages/files/TableFilesSync/DirRow.tsx
@@ -38,7 +38,6 @@ export default function DirRow({ value }: { value: DirSync }) {
                 ...file,
                 date: new Date(file.date),
                 name: file.filename,
-                id: file.relativePath,
                 type: TreeType.file as const,
                 expanded: false,
               })),

--- a/front/src/generated/graphql.tsx
+++ b/front/src/generated/graphql.tsx
@@ -51,7 +51,6 @@ export type EditFileSyncOptionInput = {
   topics: Array<Scalars['String']>;
 };
 
-/** Main event type */
 export type Event = {
   createdAt: Scalars['DateTime'];
   data: EventData;
@@ -86,7 +85,6 @@ export type EventFilterInput = {
   topic?: Maybe<Scalars['String']>;
 };
 
-/** Intermediary type for event data */
 export type EventHistory = {
   date: Scalars['DateTime'];
   message?: Maybe<Scalars['String']>;
@@ -104,7 +102,6 @@ export type EventProcessor = {
   processorId: Scalars['String'];
 };
 
-/** Paginated list of events */
 export enum EventSortField {
   CREATEDAT = 'createdAt',
   DATE = 'date',
@@ -118,7 +115,6 @@ export type EventSortInput = {
   field: EventSortField;
 };
 
-/** Enums for event fields */
 export enum EventStatus {
   ERROR = 'error',
   PENDING = 'pending',

--- a/front/src/hooks/useEventQuery.ts
+++ b/front/src/hooks/useEventQuery.ts
@@ -73,10 +73,14 @@ export function useFilterEventQuery(): [
 ] {
   const setQuery = useSetEventQuery();
   const query = useQuery();
-  const statusList = query.status?.split(',').map((s) => {
-    const value = s.trim() as EventStatus;
-    return { value, label: value };
-  }) ?? [{ value: EventStatus.PENDING, label: EventStatus.PENDING }];
+  const statusList =
+    query.status
+      ?.split(',')
+      .filter((s) => !!s)
+      .map((s) => {
+        const value = s.trim() as EventStatus;
+        return { value, label: value };
+      }) ?? [];
   const sortField =
     (query.sortField as EventSortField) || EventSortField.CREATEDAT;
   const sortDirection =

--- a/front/src/hooks/useFileQuery.ts
+++ b/front/src/hooks/useFileQuery.ts
@@ -87,10 +87,14 @@ export function useFilterFilesQuery(
 ): [Nullable<FilterQuery>, (newQuery: Nullable<FilterQuery>) => void] {
   const setQuery = useSetFilesQuery(base);
   const query = useQuery();
-  const statusList = query.status?.split(',').map((s) => {
-    const value = s.trim() as FileStatus;
-    return { value, label: value };
-  }) ?? [{ value: FileStatus.IMPORTED, label: FileStatus.IMPORTED }];
+  const statusList =
+    query.status
+      ?.split(',')
+      .filter((s) => !!s)
+      .map((s) => {
+        const value = s.trim() as FileStatus;
+        return { value, label: value };
+      }) ?? [];
   const minSize = query.minSize ? bytes(query.minSize).toString() : null;
   const maxSize = query.maxSize ? bytes(query.maxSize).toString() : null;
   const minDate = query.minDate ? new Date(query.minDate) : null;


### PR DESCRIPTION
- Allow empty status for events and files filters forms
- An empty array of status means to query all possible statuses